### PR TITLE
Fix null access to communityCd

### DIFF
--- a/community-web-vue/community/src/components/Personal.vue
+++ b/community-web-vue/community/src/components/Personal.vue
@@ -90,7 +90,19 @@ export default {
       }
     }
     return{
-      personalForm:{},
+      personalForm:{
+        workNo:"",
+        username:"",
+        sex:"",
+        phone:"",
+        communityCd:"",
+        roleId:"",
+        hospitalId:"",
+        departmentId:"",
+        password:"",
+        newPassword:"",
+        passwordConfirm:""
+      },
       options: [
         {
           roleId: '1',

--- a/community-web-vue/community/src/components/User/OlderInfoList.vue
+++ b/community-web-vue/community/src/components/User/OlderInfoList.vue
@@ -227,8 +227,20 @@ export default {
       insertOlder:false,
       editOlderForm:{
         photo:"",
+        communityCd:"",
+        olderName:"",
+        userId:"",
+        address:"",
+        medicalHistory:""
       },
-      addOlderForm:{olderAge:""},
+      addOlderForm:{
+        olderAge:"",
+        communityCd:"",
+        olderName:"",
+        userId:"",
+        medicalHistory:"",
+        photo:""
+      },
       editDialogVisible: false,
       addFormRules:{
         photo:[

--- a/community-web-vue/community/src/components/User/UserList.vue
+++ b/community-web-vue/community/src/components/User/UserList.vue
@@ -175,6 +175,8 @@ export default {
       }],
       // 查询信息实体
       queryInfo:{
+        username:"",
+        communityCd:"",
         pageNum: 1,//当前页
         pageSize: 10,//每页最大数
       },
@@ -184,12 +186,23 @@ export default {
 
       //修改用户信息
       editForm:{
+        communityCd:"",
+        username:"",
+        sex:"",
+        phone:"",
+        roleId:""
       },
       //显示、隐藏修改用户栏
       editDialogVisible:false,
 
       //新增表单信息
       addForm:{
+        communityCd:"",
+        username:"",
+        password:"",
+        sex:"",
+        phone:"",
+        roleId:"4"
       },
       //表单校验
       addFormRules:{

--- a/community-web-vue/community/src/components/community/CommunityList.vue
+++ b/community-web-vue/community/src/components/community/CommunityList.vue
@@ -149,6 +149,7 @@ export default {
       communityList:[],
       // 查询信息实体
       queryInfo:{
+        communityCd:"",
         pageNum: 1,//当前页
         pageSize: 10,//每页最大数
       },
@@ -157,8 +158,22 @@ export default {
       isDisabled:false,
       isInsert:false,//对话框状态
       isShowInfo:false,
-      communityForm:{},
-      addForm:{},
+      communityForm:{
+        communityCd:"",
+        communityName:"",
+        communityPlace:"",
+        communityArea:"",
+        peopleNumber:"",
+        oldNumber:""
+      },
+      addForm:{
+        communityCd:"",
+        communityName:"",
+        communityPlace:"",
+        communityArea:"",
+        peopleNumber:"",
+        oldNumber:""
+      },
       editFormRules:{
         communityCd:[
           {required: true,message:"请输入社区编号",trigger:"blur"},

--- a/community-web-vue/community/src/components/mutualAid/Food/foodBusiness.vue
+++ b/community-web-vue/community/src/components/mutualAid/Food/foodBusiness.vue
@@ -159,7 +159,12 @@ export default {
   data(){
     return{
       imgUrl:"",
-      queryInfo:{},
+      queryInfo:{
+        communityCd:"",
+        restaurant:"",
+        pageNum:1,
+        pageSize:10
+      },
       addFoodOrderForm:{
         foodNumber:0,
         foodPrice: ""
@@ -170,10 +175,19 @@ export default {
       foodList:[],
       isMenu:false,
       isAddFood:false,
-      addMenuForm:{},
+      addMenuForm:{
+        communityCd:"",
+        restaurant:""
+      },
       total:0,
       token:"",
-      addFoodForm:{},
+      addFoodForm:{
+        communityCd:"",
+        restaurant:"",
+        foodName:"",
+        foodPrice:"",
+        foodImgUrl:""
+      },
       addMenuFormRules:{
         communityCd:[
           {required: true,message:"请输入社区编号",trigger:"blur"}


### PR DESCRIPTION
## Summary
- initialize query objects and forms with communityCd and related fields
- include blank values to avoid `communityCd` null errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852a7a6b2c4832686806f9b0035b603