### PR TITLE
Fix null items causing communityCd errors

### DIFF
--- a/community-web-vue/community/src/components/Login.vue
+++ b/community-web-vue/community/src/components/Login.vue
@@ -196,7 +196,7 @@ export default {
     // 获取社区列表
     async selectAddress() {
       const { data: res } = await this.$http.get('/User/address');
-      this.communities = res || [];
+      this.communities = Array.isArray(res) ? res.filter(item => item) : [];
     },
     // 登录
     login() {

--- a/community-web-vue/community/src/components/Personal.vue
+++ b/community-web-vue/community/src/components/Personal.vue
@@ -90,7 +90,19 @@ export default {
       }
     }
     return{
-      personalForm:{},
+      personalForm:{
+        workNo:"",
+        username:"",
+        sex:"",
+        phone:"",
+        communityCd:"",
+        roleId:"",
+        hospitalId:"",
+        departmentId:"",
+        password:"",
+        newPassword:"",
+        passwordConfirm:""
+      },
       options: [
         {
           roleId: '1',
@@ -139,7 +151,7 @@ export default {
   methods:{
     async selectAddress(){
       const {data:res} = await this.$http.get("/User/address");
-      this.communities = res;
+      this.communities = Array.isArray(res) ? res.filter(item => item) : [];
     },
     async getHospitalDrop(){
       const{data:res} = await this.$http.get("/medical/hospitalDrop",)

--- a/community-web-vue/community/src/components/User/OlderInfoList.vue
+++ b/community-web-vue/community/src/components/User/OlderInfoList.vue
@@ -227,8 +227,20 @@ export default {
       insertOlder:false,
       editOlderForm:{
         photo:"",
+        communityCd:"",
+        olderName:"",
+        userId:"",
+        address:"",
+        medicalHistory:""
       },
-      addOlderForm:{olderAge:""},
+      addOlderForm:{
+        olderAge:"",
+        communityCd:"",
+        olderName:"",
+        userId:"",
+        medicalHistory:"",
+        photo:""
+      },
       editDialogVisible: false,
       addFormRules:{
         photo:[
@@ -284,7 +296,7 @@ export default {
     },
     async selectAddress(){
       const {data:res} = await this.$http.get("/User/address");
-      this.communities = res || [];
+      this.communities = Array.isArray(res) ? res.filter(item => item) : [];
     },
     async selectUserList(){
       const {data:res} = await this.$http.get("/older/userList")

--- a/community-web-vue/community/src/components/User/UserList.vue
+++ b/community-web-vue/community/src/components/User/UserList.vue
@@ -175,6 +175,8 @@ export default {
       }],
       // 查询信息实体
       queryInfo:{
+        username:"",
+        communityCd:"",
         pageNum: 1,//当前页
         pageSize: 10,//每页最大数
       },
@@ -184,12 +186,23 @@ export default {
 
       //修改用户信息
       editForm:{
+        communityCd:"",
+        username:"",
+        sex:"",
+        phone:"",
+        roleId:""
       },
       //显示、隐藏修改用户栏
       editDialogVisible:false,
 
       //新增表单信息
       addForm:{
+        communityCd:"",
+        username:"",
+        password:"",
+        sex:"",
+        phone:"",
+        roleId:"4"
       },
       //表单校验
       addFormRules:{
@@ -271,7 +284,7 @@ export default {
     },
     async selectAddress(){
       const {data:res} = await this.$http.get("/User/address");
-      this.communities = res || [];
+      this.communities = Array.isArray(res) ? res.filter(item => item) : [];
     },
     // 监听添加用户
     insertClosed(){

--- a/community-web-vue/community/src/components/admin/WorkerList.vue
+++ b/community-web-vue/community/src/components/admin/WorkerList.vue
@@ -362,7 +362,9 @@ export default {
     },
     //监听添加
     insertClosed() {
-      this.$refs.editFormRef.resetFields();//重置信息
+      if(this.$refs.addFormRef){
+        this.$refs.addFormRef.resetFields();//重置信息
+      }
     }
   }
 }

--- a/community-web-vue/community/src/components/community/CommunityList.vue
+++ b/community-web-vue/community/src/components/community/CommunityList.vue
@@ -149,6 +149,7 @@ export default {
       communityList:[],
       // 查询信息实体
       queryInfo:{
+        communityCd:"",
         pageNum: 1,//当前页
         pageSize: 10,//每页最大数
       },
@@ -157,8 +158,22 @@ export default {
       isDisabled:false,
       isInsert:false,//对话框状态
       isShowInfo:false,
-      communityForm:{},
-      addForm:{},
+      communityForm:{
+        communityCd:"",
+        communityName:"",
+        communityPlace:"",
+        communityArea:"",
+        peopleNumber:"",
+        oldNumber:""
+      },
+      addForm:{
+        communityCd:"",
+        communityName:"",
+        communityPlace:"",
+        communityArea:"",
+        peopleNumber:"",
+        oldNumber:""
+      },
       editFormRules:{
         communityCd:[
           {required: true,message:"请输入社区编号",trigger:"blur"},
@@ -219,7 +234,7 @@ export default {
     },
     async selectAddress(){
       const {data:res} = await this.$http.get("/User/address");
-      this.communities = res || [];
+      this.communities = Array.isArray(res) ? res.filter(item => item) : [];
     },
     async showInfo(id){
         this.isShowInfo = true;

--- a/community-web-vue/community/src/components/mutualAid/Food/foodBusiness.vue
+++ b/community-web-vue/community/src/components/mutualAid/Food/foodBusiness.vue
@@ -159,7 +159,12 @@ export default {
   data(){
     return{
       imgUrl:"",
-      queryInfo:{},
+      queryInfo:{
+        communityCd:"",
+        restaurant:"",
+        pageNum:1,
+        pageSize:10
+      },
       addFoodOrderForm:{
         foodNumber:0,
         foodPrice: ""
@@ -170,10 +175,19 @@ export default {
       foodList:[],
       isMenu:false,
       isAddFood:false,
-      addMenuForm:{},
+      addMenuForm:{
+        communityCd:"",
+        restaurant:""
+      },
       total:0,
       token:"",
-      addFoodForm:{},
+      addFoodForm:{
+        communityCd:"",
+        restaurant:"",
+        foodName:"",
+        foodPrice:"",
+        foodImgUrl:""
+      },
       addMenuFormRules:{
         communityCd:[
           {required: true,message:"请输入社区编号",trigger:"blur"}
@@ -265,7 +279,7 @@ export default {
     async selectAddress(){
       this.token = window.sessionStorage.getItem('roleId')
       const {data:res} = await this.$http.get("/User/address");
-      this.communities = res;
+      this.communities = Array.isArray(res) ? res.filter(item => item) : [];
     },
     handleSizeChange(newSize){
       this.queryInfo.pageSize = newSize;

--- a/community-web-vue/community/src/components/mutualAid/Pharmacy/Appointment.vue
+++ b/community-web-vue/community/src/components/mutualAid/Pharmacy/Appointment.vue
@@ -258,7 +258,12 @@ export default {
       })
     },
     addClosed(){
-      this.$refs.addHospitalFormRef.resetFields();
+      if(this.$refs.addHospitalFormRef){
+        this.$refs.addHospitalFormRef.resetFields();
+      }
+      if(this.$refs.addAppointFormRef){
+        this.$refs.addAppointFormRef.resetFields();
+      }
     },
     async getHospitalList(){
       this.token = window.sessionStorage.getItem("roleId")


### PR DESCRIPTION
## Summary
- filter out null items in `selectAddress` across components
- initialize defaults for community-based forms
- reset both appointment and hospital forms correctly
- reset the add worker form on close

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852a7a6b2c4832686806f9b0035b603